### PR TITLE
Error handling & base64 certificate support

### DIFF
--- a/src/common/services/proof.service.ts
+++ b/src/common/services/proof.service.ts
@@ -100,7 +100,7 @@ export class ProofService {
     try {
       didDocument = await this.getDidWebDocument(did)
     } catch (error) {
-      throw new ConflictException(`Could not load document for given did:web: "${did}"`)
+      throw new ConflictException(`Could not load document for given did:web: "${did}", reason:\n${error}`)
     }
     if (!didDocument?.verificationMethod || didDocument?.verificationMethod?.constructor !== Array) {
       throw new ConflictException(`Could not load verificationMethods in did document at ${didDocument?.verificationMethod}`)
@@ -120,6 +120,17 @@ export class ProofService {
 
   private async getDidWebDocument(did: string): Promise<DIDDocument> {
     const doc = await resolver.resolve(did)
+    if (!doc.didDocument) {
+      const metaData = doc.didResolutionMetadata as Record<string, any>
+      let errorMsg = `Could not resolve ${did}`
+      if (metaData.error !== undefined) {
+        errorMsg += `, error: ${metaData.error}`
+      }
+      if (metaData.message !== undefined) {
+        errorMsg += `, message:\n ${metaData.message}`
+      }
+      throw new Error(errorMsg)
+    }
 
     return doc.didDocument
   }

--- a/src/common/utils/public-key.utils.ts
+++ b/src/common/utils/public-key.utils.ts
@@ -1,9 +1,20 @@
-import { writeFileSync } from 'fs'
-import { join } from 'path'
+import {writeFileSync} from 'fs'
+import {join} from 'path'
+
+function parseCertificate() {
+    const certificateData = process.env.X509_CERTIFICATE;
+
+    // Check if the certificate data contains "-----"
+    if (certificateData.includes("-----")) {
+        return certificateData;
+    } else {
+        return atob(certificateData);
+    }
+}
 
 export function importCertChain() {
-  if (!!process.env.X509_CERTIFICATE) {
-    const X509_CERTIFICATE_CHAIN_FILE_PATH = join(__dirname, '../../static/.well-known/x509CertificateChain.pem')
-    writeFileSync(X509_CERTIFICATE_CHAIN_FILE_PATH, process.env.X509_CERTIFICATE)
-  }
+    if (!!process.env.X509_CERTIFICATE) {
+        const X509_CERTIFICATE_CHAIN_FILE_PATH = join(__dirname, '../../static/.well-known/x509CertificateChain.pem')
+        writeFileSync(X509_CERTIFICATE_CHAIN_FILE_PATH, parseCertificate())
+    }
 }


### PR DESCRIPTION
Passing raw pem files in dock-compose.yml did't work, so it now accepts base64 encoded as well